### PR TITLE
ISSUE 1: add null guard fallback to getObjectId for peeled objects without peeled ids.

### DIFF
--- a/src/main/java/me/qoomon/gitversioning/GitUtil.java
+++ b/src/main/java/me/qoomon/gitversioning/GitUtil.java
@@ -36,7 +36,7 @@ public final class GitUtil {
         ObjectId rev = unchecked(() -> repository.resolve(revstr));
         return unchecked(() -> repository.getRefDatabase().getRefsByPrefix(R_TAGS)).stream()
                 .map(ref -> unchecked(() -> repository.getRefDatabase().peel(ref)))
-                .filter(ref -> (ref.isPeeled() ? ref.getPeeledObjectId() : ref.getObjectId()).equals(rev))
+                .filter(ref -> (ref.isPeeled() && ref.getPeeledObjectId() != null ? ref.getPeeledObjectId() : ref.getObjectId()).equals(rev))
                 .map(ref -> ref.getName().replaceFirst("^" + R_TAGS, ""))
                 .collect(toList());
     }

--- a/src/test/java/me/qoomon/gitversioning/GitUtilTest.java
+++ b/src/test/java/me/qoomon/gitversioning/GitUtilTest.java
@@ -149,24 +149,21 @@ class GitUtilTest {
     }
 
     @Test
-    void tag_pointsAt_unannotedTag() throws GitAPIException {
+    void tag_pointsAt_lightweightTag() throws GitAPIException {
 
         // given
         Git git = Git.init().setDirectory(tempDir.toFile()).call();
 
         RevCommit givenCommit = git.commit().setMessage("initial commit").setAllowEmpty(true).call();
-        String givenTagName1 = "111";
-        git.tag().setName(givenTagName1).setObjectId(givenCommit).call();
-        String givenTagName2 = "222";
-        git.tag().setName(givenTagName2).setObjectId(givenCommit).call();
-        String givenTagName3 = "333";
-        git.tag().setName(givenTagName3).setAnnotated(false).setObjectId(givenCommit).call();
+
+        String givenTagName = "v1.0.0-1234";
+        git.tag().setName(givenTagName).setAnnotated(false).setObjectId(givenCommit).call();
 
         // when
         List<String> tags = GitUtil.tag_pointsAt(git.getRepository(), HEAD);
 
         // then
-        assertThat(tags).containsExactlyInAnyOrder(givenTagName1, givenTagName2, givenTagName3);
+        assertThat(tags).containsExactlyInAnyOrder(givenTagName);
     }
 
     @Test

--- a/src/test/java/me/qoomon/gitversioning/GitUtilTest.java
+++ b/src/test/java/me/qoomon/gitversioning/GitUtilTest.java
@@ -149,6 +149,27 @@ class GitUtilTest {
     }
 
     @Test
+    void tag_pointsAt_unannotedTag() throws GitAPIException {
+
+        // given
+        Git git = Git.init().setDirectory(tempDir.toFile()).call();
+
+        RevCommit givenCommit = git.commit().setMessage("initial commit").setAllowEmpty(true).call();
+        String givenTagName1 = "111";
+        git.tag().setName(givenTagName1).setObjectId(givenCommit).call();
+        String givenTagName2 = "222";
+        git.tag().setName(givenTagName2).setObjectId(givenCommit).call();
+        String givenTagName3 = "333";
+        git.tag().setName(givenTagName3).setAnnotated(false).setObjectId(givenCommit).call();
+
+        // when
+        List<String> tags = GitUtil.tag_pointsAt(git.getRepository(), HEAD);
+
+        // then
+        assertThat(tags).containsExactlyInAnyOrder(givenTagName1, givenTagName2, givenTagName3);
+    }
+
+    @Test
     void revParse_emptyRepo() throws GitAPIException {
 
         // given


### PR DESCRIPTION
Properly handle the case when a peeled object has no peeled id (e.g. lightweight tags).