### PR TITLE
Support next by distance and label as number

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ gitVersioning.apply {
 
 ```kotlin
 plugins {
-    id("me.qoomon.git-versioning") version "5.2.0"
+    id("me.qoomon.git-versioning") version "6.2.0"
 }
 
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,6 @@ e.g `${dirty:-SNAPSHOT}` resolves to `-SNAPSHOT` instead of `-DIRTY`
     - `${version.patch.next}` the `${version.patch}` increased by 1 e.g. '4'
   - `${version.label}` the version label of `${version}` e.g. 'SNAPSHOT'
     - `${version.label.prefixed}` like `${version.label}` with label separator e.g. '-SNAPSHOT'
-    - `${version.label.number}` used to extract the label as a number (build will fail if non-numeric label encountered for this)
 - Project Version Pattern Groups
   - Content of regex groups in `projectVersionPattern` can be addressed like this:
   - `${version.GROUP_NAME}`
@@ -257,9 +256,8 @@ e.g `${dirty:-SNAPSHOT}` resolves to `-SNAPSHOT` instead of `-DIRTY`
       - `${describe.tag.version.patch.next}` the `${describe.tag.version.patch}` increased by 1 e.g. '4'
       - `${describe.tag.version.patch.nextByDistance}` the `${describe.tag.version.patch}` increased by `${describe.distance}` + 1 e.g. '2'
     - `${describe.tag.version.label}` the label version component of `${describe.tag.version}` e.g. 'SNAPSHOT'
-    - `${describe.tag.version.label.number}` the `${describe.tag.version.label}` assuming numeric e,g, '5', will cause build failure if a non-numeric label is found
-      - `${describe.tag.version.label.number.next}` the `${describe.tag.version.label.number}` increased by 1 e.g. '6', will cause build failure if a non-numeric label is found
-      - `${describe.tag.version.label.number.nextByDistance}` the `${describe.tag.version.label.number}` increased by `${describe.distance}` + 1 e.g. '9', will cause build failure if a non-numeric label is found
+      - `${describe.tag.version.label.asInt.next}` the `${describe.tag.version.label}` converted to an integer and increased by 1 e.g. '6'
+      - `${describe.tag.version.label.asInt.nextByDistance}` the `${describe.tag.version.label}` converted to an integer increased by `${describe.distance}` + 1 e.g. '9'
 - Describe Tag Pattern Groups
   - Content of regex groups in `describeTagPattern` can be addressed like this:
   - `${describe.tag.GROUP_NAME}` `${describe.tag.GROUP_NAME.slug}`

--- a/README.md
+++ b/README.md
@@ -248,16 +248,16 @@ e.g `${dirty:-SNAPSHOT}` resolves to `-SNAPSHOT` instead of `-DIRTY`
     - `${describe.tag.version.core}` the core version component of `${describe.tag.version}` e.g. '1.2.3'
     - `${describe.tag.version.major}` the major version component of `${describe.tag.version}` e.g. '1'
       - `${describe.tag.version.major.next}` the `${describe.tag.version.major}` increased by 1 e.g. '2'
-      - `${describe.tag.version.major.nextByDistance}` the `${describe.tag.version.major}` increased by `${describe.distance}` + 1 e.g. '2'
+      - `${describe.tag.version.major.nextPlusDistance}` the `${describe.tag.version.major}` increased by `${describe.distance}` + 1 e.g. '2'
     - `${describe.tag.version.minor}` the minor version component of `${describe.tag.version}` e.g. '2'
       - `${describe.tag.version.minor.next}` the `${describe.tag.version.minor}` increased by 1 e.g. '3'
-      - `${describe.tag.version.minor.nextByDistance}` the `${describe.tag.version.minor}` increased by `${describe.distance}` + 1 e.g. '2'
+      - `${describe.tag.version.minor.nextPlusDistance}` the `${describe.tag.version.minor}` increased by `${describe.distance}` + 1 e.g. '2'
     - `${describe.tag.version.patch}` the patch version component of `${describe.tag.version}` e.g. '3'
       - `${describe.tag.version.patch.next}` the `${describe.tag.version.patch}` increased by 1 e.g. '4'
-      - `${describe.tag.version.patch.nextByDistance}` the `${describe.tag.version.patch}` increased by `${describe.distance}` + 1 e.g. '2'
+      - `${describe.tag.version.patch.nextPlusDistance}` the `${describe.tag.version.patch}` increased by `${describe.distance}` + 1 e.g. '2'
     - `${describe.tag.version.label}` the label version component of `${describe.tag.version}` e.g. 'SNAPSHOT'
-      - `${describe.tag.version.label.asInt.next}` the `${describe.tag.version.label}` converted to an integer and increased by 1 e.g. '6'
-      - `${describe.tag.version.label.asInt.nextByDistance}` the `${describe.tag.version.label}` converted to an integer increased by `${describe.distance}` + 1 e.g. '9'
+      - `${describe.tag.version.label.next}` the `${describe.tag.version.label}` converted to an integer and increased by 1 e.g. '6'
+      - `${describe.tag.version.label.nextPlusDistance}` the `${describe.tag.version.label}` converted to an integer increased by `${describe.distance}` + 1 e.g. '9'
 - Describe Tag Pattern Groups
   - Content of regex groups in `describeTagPattern` can be addressed like this:
   - `${describe.tag.GROUP_NAME}` `${describe.tag.GROUP_NAME.slug}`

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ e.g `${dirty:-SNAPSHOT}` resolves to `-SNAPSHOT` instead of `-DIRTY`
     - `${version.patch.next}` the `${version.patch}` increased by 1 e.g. '4'
   - `${version.label}` the version label of `${version}` e.g. 'SNAPSHOT'
     - `${version.label.prefixed}` like `${version.label}` with label separator e.g. '-SNAPSHOT'
+    - `${version.label.number}` used to extract the label as a number (build will fail if non-numeric label encountered for this)
 - Project Version Pattern Groups
   - Content of regex groups in `projectVersionPattern` can be addressed like this:
   - `${version.GROUP_NAME}`
@@ -248,10 +249,17 @@ e.g `${dirty:-SNAPSHOT}` resolves to `-SNAPSHOT` instead of `-DIRTY`
     - `${describe.tag.version.core}` the core version component of `${describe.tag.version}` e.g. '1.2.3'
     - `${describe.tag.version.major}` the major version component of `${describe.tag.version}` e.g. '1'
       - `${describe.tag.version.major.next}` the `${describe.tag.version.major}` increased by 1 e.g. '2'
-    - `${describe.tag.version.minor}` the major version component of `${describe.tag.version}` e.g. '2'
+      - `${describe.tag.version.major.nextByDistance}` the `${describe.tag.version.major}` increased by `${describe.distance}` + 1 e.g. '2'
+    - `${describe.tag.version.minor}` the minor version component of `${describe.tag.version}` e.g. '2'
       - `${describe.tag.version.minor.next}` the `${describe.tag.version.minor}` increased by 1 e.g. '3'
-    - `${describe.tag.version.path}` the major version component of `${describe.tag.version}` e.g. '3'
+      - `${describe.tag.version.minor.nextByDistance}` the `${describe.tag.version.minor}` increased by `${describe.distance}` + 1 e.g. '2'
+    - `${describe.tag.version.patch}` the patch version component of `${describe.tag.version}` e.g. '3'
       - `${describe.tag.version.patch.next}` the `${describe.tag.version.patch}` increased by 1 e.g. '4'
+      - `${describe.tag.version.patch.nextByDistance}` the `${describe.tag.version.patch}` increased by `${describe.distance}` + 1 e.g. '2'
+    - `${describe.tag.version.label}` the label version component of `${describe.tag.version}` e.g. 'SNAPSHOT'
+    - `${describe.tag.version.label.number}` the `${describe.tag.version.label}` assuming numeric e,g, '5', will cause build failure if a non-numeric label is found
+      - `${describe.tag.version.label.number.next}` the `${describe.tag.version.label.number}` increased by 1 e.g. '6', will cause build failure if a non-numeric label is found
+      - `${describe.tag.version.label.number.nextByDistance}` the `${describe.tag.version.label.number}` increased by `${describe.distance}` + 1 e.g. '9', will cause build failure if a non-numeric label is found
 - Describe Tag Pattern Groups
   - Content of regex groups in `describeTagPattern` can be addressed like this:
   - `${describe.tag.GROUP_NAME}` `${describe.tag.GROUP_NAME.slug}`

--- a/README.md
+++ b/README.md
@@ -248,16 +248,16 @@ e.g `${dirty:-SNAPSHOT}` resolves to `-SNAPSHOT` instead of `-DIRTY`
     - `${describe.tag.version.core}` the core version component of `${describe.tag.version}` e.g. '1.2.3'
     - `${describe.tag.version.major}` the major version component of `${describe.tag.version}` e.g. '1'
       - `${describe.tag.version.major.next}` the `${describe.tag.version.major}` increased by 1 e.g. '2'
-      - `${describe.tag.version.major.nextPlusDistance}` the `${describe.tag.version.major}` increased by `${describe.distance}` + 1 e.g. '2'
     - `${describe.tag.version.minor}` the minor version component of `${describe.tag.version}` e.g. '2'
       - `${describe.tag.version.minor.next}` the `${describe.tag.version.minor}` increased by 1 e.g. '3'
-      - `${describe.tag.version.minor.nextPlusDistance}` the `${describe.tag.version.minor}` increased by `${describe.distance}` + 1 e.g. '2'
     - `${describe.tag.version.patch}` the patch version component of `${describe.tag.version}` e.g. '3'
       - `${describe.tag.version.patch.next}` the `${describe.tag.version.patch}` increased by 1 e.g. '4'
-      - `${describe.tag.version.patch.nextPlusDistance}` the `${describe.tag.version.patch}` increased by `${describe.distance}` + 1 e.g. '2'
+      - `${describe.tag.version.patch.plus.describe.distance}` the `${describe.tag.version.patch}` increased by `${describe.distance}` e.g. '2'
+      - `${describe.tag.version.patch.next.plus.describe.distance}` the `${describe.tag.version.patch.next}` increased by `${describe.distance}` e.g. '3'
     - `${describe.tag.version.label}` the label version component of `${describe.tag.version}` e.g. 'SNAPSHOT'
       - `${describe.tag.version.label.next}` the `${describe.tag.version.label}` converted to an integer and increased by 1 e.g. '6'
-      - `${describe.tag.version.label.nextPlusDistance}` the `${describe.tag.version.label}` converted to an integer increased by `${describe.distance}` + 1 e.g. '9'
+      - `${describe.tag.version.label.plus.describe.distance}` the `${describe.tag.version.label}` increased by `${describe.distance}` e.g. '2'
+      - `${describe.tag.version.label.next.plus.describe.distance}` the `${describe.tag.version.label.next}` increased by `${describe.distance}` e.g. '3'
 - Describe Tag Pattern Groups
   - Content of regex groups in `describeTagPattern` can be addressed like this:
   - `${describe.tag.GROUP_NAME}` `${describe.tag.GROUP_NAME.slug}`

--- a/src/main/java/me/qoomon/gitversioning/commons/GitUtil.java
+++ b/src/main/java/me/qoomon/gitversioning/commons/GitUtil.java
@@ -61,26 +61,24 @@ public final class GitUtil {
             walk.setFirstParent(true);
             walk.markStart(walk.parseCommit(revObjectId));
             Iterator<RevCommit> walkIterator = walk.iterator();
-            int depth = -1;
+            int depth = 0;
             while (walkIterator.hasNext()) {
                 RevCommit rev = walkIterator.next();
-                depth++;
-                Optional<String> matchingTag = objectIdListMap.getOrDefault(rev, emptyList()).stream()
+                 Optional<String> matchingTag = objectIdListMap.getOrDefault(rev, emptyList()).stream()
                         .filter(tag -> tagPattern.matcher(tag).matches())
                         .findFirst();
 
                 if (matchingTag.isPresent()) {
                     return new GitDescription(revObjectId.getName(), matchingTag.get(), depth);
                 }
+                depth++;
             }
 
             if (isShallowRepository(repository)) {
                 throw new IllegalStateException("couldn't find matching tag in shallow git repository");
             }
 
-            // If no matching tag found, then we should presumably return the number of commits on the branch
-            // but we started from -1 so need to compensate here
-            return new GitDescription(revObjectId.getName(), "root", depth + 1);
+            return new GitDescription(revObjectId.getName(), "root", depth);
         }
     }
 

--- a/src/main/java/me/qoomon/gitversioning/commons/GitUtil.java
+++ b/src/main/java/me/qoomon/gitversioning/commons/GitUtil.java
@@ -78,7 +78,9 @@ public final class GitUtil {
                 throw new IllegalStateException("couldn't find matching tag in shallow git repository");
             }
 
-            return new GitDescription(revObjectId.getName(), "root", depth);
+            // If no matching tag found, then we should presumably return the number of commits on the branch
+            // but we started from -1 so need to compensate here
+            return new GitDescription(revObjectId.getName(), "root", depth + 1);
         }
     }
 

--- a/src/main/java/me/qoomon/gradle/gitversioning/GitVersioningPluginExtension.java
+++ b/src/main/java/me/qoomon/gradle/gitversioning/GitVersioningPluginExtension.java
@@ -573,19 +573,19 @@ public abstract class GitVersioningPluginExtension {
 
         placeholderMap.put("describe.tag.version.major", Lazy.by(() -> notNullOrDefault(descriptionTagVersionComponents.get().group("major"), "0")));
         placeholderMap.put("describe.tag.version.major.next", Lazy.by(() -> increaseStringNumber(placeholderMap.get("describe.tag.version.major").get())));
-        placeholderMap.put("describe.tag.version.major.nextPlusDistance", Lazy.by(() -> increaseStringNumberBy(placeholderMap.get("describe.tag.version.major").get(), distance.get() + 1)));
 
         placeholderMap.put("describe.tag.version.minor", Lazy.by(() -> notNullOrDefault(descriptionTagVersionComponents.get().group("minor"), "0")));
         placeholderMap.put("describe.tag.version.minor.next", Lazy.by(() -> increaseStringNumber(placeholderMap.get("describe.tag.version.minor").get())));
-        placeholderMap.put("describe.tag.version.minor.nextPlusDistance", Lazy.by(() -> increaseStringNumberBy(placeholderMap.get("describe.tag.version.minor").get(), distance.get() + 1)));
 
         placeholderMap.put("describe.tag.version.patch", Lazy.by(() -> notNullOrDefault(descriptionTagVersionComponents.get().group("patch"), "0")));
         placeholderMap.put("describe.tag.version.patch.next", Lazy.by(() -> increaseStringNumber(placeholderMap.get("describe.tag.version.patch").get())));
-        placeholderMap.put("describe.tag.version.patch.nextPlusDistance", Lazy.by(() -> increaseStringNumberBy(placeholderMap.get("describe.tag.version.patch").get(), distance.get() + 1)));
+        placeholderMap.put("describe.tag.version.patch.plus.describe.distance", Lazy.by(() -> increaseStringNumberBy(placeholderMap.get("describe.tag.version.patch").get(), distance.get() )));
+        placeholderMap.put("describe.tag.version.patch.next.plus.describe.distance", Lazy.by(() -> increaseStringNumberBy(placeholderMap.get("describe.tag.version.patch").get(), distance.get() + 1)));
 
         placeholderMap.put("describe.tag.version.version.label", Lazy.by(() -> notNullOrDefault(descriptionTagVersionComponents.get().group("label"), "")));
         placeholderMap.put("describe.tag.version.label.next", Lazy.by(() -> increaseStringNumber(labelAsInteger.get())));
-        placeholderMap.put("describe.tag.version.label.nextPlusDistance", Lazy.by(() -> increaseStringNumberBy(labelAsInteger.get(), distance.get() + 1)));
+        placeholderMap.put("describe.tag.version.label.plus.describe.distance", Lazy.by(() -> increaseStringNumberBy(labelAsInteger.get(), distance.get())));
+        placeholderMap.put("describe.tag.version.label.next.plus.describe.distance", Lazy.by(() -> increaseStringNumberBy(labelAsInteger.get(), distance.get() + 1)));
 
         placeholderMap.put("describe.distance", Lazy.by(() -> String.valueOf(description.get().getDistance())));
 

--- a/src/main/java/me/qoomon/gradle/gitversioning/GitVersioningPluginExtension.java
+++ b/src/main/java/me/qoomon/gradle/gitversioning/GitVersioningPluginExtension.java
@@ -482,7 +482,6 @@ public abstract class GitVersioningPluginExtension {
             String label = placeholderMap.get("version.label").get();
             return !label.isEmpty() ? "-" + label : "";
         }));
-        placeholderMap.put("version.label.number", Lazy.by(() -> extractLabelNumber(versionComponents)));
 
         // deprecated
         placeholderMap.put("version.release",  Lazy.by(() -> projectVersion.replaceFirst("-.*$", "")));
@@ -568,6 +567,8 @@ public abstract class GitVersioningPluginExtension {
             return matcher;
         });
 
+        final Lazy<String> labelAsInteger = Lazy.by(() -> extractLabelNumber(descriptionTagVersionComponents));
+
         placeholderMap.put("describe.tag.version.core", Lazy.by(() -> notNullOrDefault(descriptionTagVersionComponents.get().group("core"), "0")));
 
         placeholderMap.put("describe.tag.version.major", Lazy.by(() -> notNullOrDefault(descriptionTagVersionComponents.get().group("major"), "0")));
@@ -583,9 +584,8 @@ public abstract class GitVersioningPluginExtension {
         placeholderMap.put("describe.tag.version.patch.nextByDistance", Lazy.by(() -> increaseStringNumberBy(placeholderMap.get("describe.tag.version.patch").get(), distance.get() + 1)));
 
         placeholderMap.put("describe.tag.version.version.label", Lazy.by(() -> notNullOrDefault(descriptionTagVersionComponents.get().group("label"), "")));
-        placeholderMap.put("describe.tag.version.label.number", Lazy.by(() -> extractLabelNumber(descriptionTagVersionComponents)));
-        placeholderMap.put("describe.tag.version.label.number.next", Lazy.by(() -> increaseStringNumber(placeholderMap.get("describe.tag.version.label.number").get())));
-        placeholderMap.put("describe.tag.version.label.number.nextByDistance", Lazy.by(() -> increaseStringNumberBy(placeholderMap.get("describe.tag.version.label.number").get(), distance.get() + 1)));
+        placeholderMap.put("describe.tag.version.label.asInt.next", Lazy.by(() -> increaseStringNumber(labelAsInteger.get())));
+        placeholderMap.put("describe.tag.version.label.asInt.nextByDistance", Lazy.by(() -> increaseStringNumberBy(labelAsInteger.get(), distance.get() + 1)));
 
         placeholderMap.put("describe.distance", Lazy.by(() -> String.valueOf(description.get().getDistance())));
 
@@ -606,7 +606,7 @@ public abstract class GitVersioningPluginExtension {
     }
 
     private String extractLabelNumber(Lazy<Matcher> versionComponents) {
-        String label = requireNonNullElse(versionComponents.get().group("label"), "0");
+        String label = notNullOrDefault(versionComponents.get().group("label"), "0");
         // This should throw a build-killing error if we are unparseable as a numeric
         return String.valueOf(Integer.parseInt(label));
     }

--- a/src/main/java/me/qoomon/gradle/gitversioning/GitVersioningPluginExtension.java
+++ b/src/main/java/me/qoomon/gradle/gitversioning/GitVersioningPluginExtension.java
@@ -573,19 +573,19 @@ public abstract class GitVersioningPluginExtension {
 
         placeholderMap.put("describe.tag.version.major", Lazy.by(() -> notNullOrDefault(descriptionTagVersionComponents.get().group("major"), "0")));
         placeholderMap.put("describe.tag.version.major.next", Lazy.by(() -> increaseStringNumber(placeholderMap.get("describe.tag.version.major").get())));
-        placeholderMap.put("describe.tag.version.major.nextByDistance", Lazy.by(() -> increaseStringNumberBy(placeholderMap.get("describe.tag.version.major").get(), distance.get() + 1)));
+        placeholderMap.put("describe.tag.version.major.nextPlusDistance", Lazy.by(() -> increaseStringNumberBy(placeholderMap.get("describe.tag.version.major").get(), distance.get() + 1)));
 
         placeholderMap.put("describe.tag.version.minor", Lazy.by(() -> notNullOrDefault(descriptionTagVersionComponents.get().group("minor"), "0")));
         placeholderMap.put("describe.tag.version.minor.next", Lazy.by(() -> increaseStringNumber(placeholderMap.get("describe.tag.version.minor").get())));
-        placeholderMap.put("describe.tag.version.minor.nextByDistance", Lazy.by(() -> increaseStringNumberBy(placeholderMap.get("describe.tag.version.minor").get(), distance.get() + 1)));
+        placeholderMap.put("describe.tag.version.minor.nextPlusDistance", Lazy.by(() -> increaseStringNumberBy(placeholderMap.get("describe.tag.version.minor").get(), distance.get() + 1)));
 
         placeholderMap.put("describe.tag.version.patch", Lazy.by(() -> notNullOrDefault(descriptionTagVersionComponents.get().group("patch"), "0")));
         placeholderMap.put("describe.tag.version.patch.next", Lazy.by(() -> increaseStringNumber(placeholderMap.get("describe.tag.version.patch").get())));
-        placeholderMap.put("describe.tag.version.patch.nextByDistance", Lazy.by(() -> increaseStringNumberBy(placeholderMap.get("describe.tag.version.patch").get(), distance.get() + 1)));
+        placeholderMap.put("describe.tag.version.patch.nextPlusDistance", Lazy.by(() -> increaseStringNumberBy(placeholderMap.get("describe.tag.version.patch").get(), distance.get() + 1)));
 
         placeholderMap.put("describe.tag.version.version.label", Lazy.by(() -> notNullOrDefault(descriptionTagVersionComponents.get().group("label"), "")));
-        placeholderMap.put("describe.tag.version.label.asInt.next", Lazy.by(() -> increaseStringNumber(labelAsInteger.get())));
-        placeholderMap.put("describe.tag.version.label.asInt.nextByDistance", Lazy.by(() -> increaseStringNumberBy(labelAsInteger.get(), distance.get() + 1)));
+        placeholderMap.put("describe.tag.version.label.next", Lazy.by(() -> increaseStringNumber(labelAsInteger.get())));
+        placeholderMap.put("describe.tag.version.label.nextPlusDistance", Lazy.by(() -> increaseStringNumberBy(labelAsInteger.get(), distance.get() + 1)));
 
         placeholderMap.put("describe.distance", Lazy.by(() -> String.valueOf(description.get().getDistance())));
 


### PR DESCRIPTION
This pull request adds the following capabilities to the qoomon plugin

1. Ability to extract a number from the label (if the label is numeric) – note that this needs to be used with care as a non-numeric label fed into this will cause a build failure – this is because we wish to use (on master) versions of the form 1.2.3-456 (where 456 is auto-generated based on previous build number – more on this shortly)
2. As well as “next” for each property, a “next by distance” where the value is incremented by the distance since the last matching tag. If there is no matching tag then the total number of commits on the repository is used instead.
 
I have a few notes/queries relating to this. We originally did this against an older version of this plugin and I have some tests (which mainly exercised the describe functionality which we added as you have added it more recently) but which covered usage of the placeholders. I notice that you don’t explicitly test usage of placeholders, but I will be very happy to add tests specifically around these placeholders if desired – I was trying to stay close to the existing conventions. Please just let me know if this is preferred.

Secondly, I notice that you have “version.label” but “describe.version.version.label” – is this intentional? My submission currently assumes the inconsistency was unintentional and I’ve changed to “describe.version.label” but again will be happy to revert this piece and make the new properties consistent with “describe.version.version.label” – again please just let me know.

Finally, outside the scope of the functionality, I updated the README to refer to the current version of the plugin - I hope this is ok.