### PR TITLE
Fixes issue where version matcher fails when version has a prefix like v1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 build/
 .idea/
 out/
+bin/

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 }
 
 group 'me.qoomon'
-version '6.3.2'
+version '6.4.0'
 sourceCompatibility = JavaVersion.VERSION_11
 targetCompatibility = JavaVersion.VERSION_11
 

--- a/src/main/java/me/qoomon/gradle/gitversioning/GitVersioningPluginExtension.java
+++ b/src/main/java/me/qoomon/gradle/gitversioning/GitVersioningPluginExtension.java
@@ -47,7 +47,7 @@ public abstract class GitVersioningPluginExtension {
 
     public static final Logger LOGGER = LoggerFactory.getLogger(GitVersioningPluginExtension.class);
 
-    private static final Pattern VERSION_PATTERN = Pattern.compile("(:?(?<core>(?<major>\\d+)(:?\\.(?<minor>\\d+)(:?\\.(?<patch>\\d+))?)?)(:?-(?<label>.*))?)?");
+    private static final Pattern VERSION_PATTERN = Pattern.compile("(:?[^\\d]*(?<core>(?<major>\\d+)(:?\\.(?<minor>\\d+)(:?\\.(?<patch>\\d+))?)?)(:?-(?<label>.*))?)?");
 
     private static final String OPTION_NAME_GIT_REF = "git.ref";
     private static final String OPTION_NAME_GIT_TAG = "git.tag";

--- a/src/main/java/me/qoomon/gradle/gitversioning/GitVersioningPluginExtension.java
+++ b/src/main/java/me/qoomon/gradle/gitversioning/GitVersioningPluginExtension.java
@@ -575,7 +575,7 @@ public abstract class GitVersioningPluginExtension {
         placeholderMap.put("describe.tag.version.patch", Lazy.by(() -> notNullOrDefault(descriptionTagVersionMatcher.get().group("patch"), "0")));
         placeholderMap.put("describe.tag.version.patch.next", Lazy.by(() -> increase(placeholderMap.get("describe.tag.version.patch").get(), 1)));
 
-        placeholderMap.put("describe.tag.version.version.label", Lazy.by(() -> notNullOrDefault(descriptionTagVersionMatcher.get().group("label"), "")));
+        placeholderMap.put("describe.tag.version.label", Lazy.by(() -> notNullOrDefault(descriptionTagVersionMatcher.get().group("label"), "")));
         placeholderMap.put("describe.tag.version.label.next", Lazy.by(() -> increase(placeholderMap.get("describe.tag.version.label").get(), 1)));
 
         final Lazy<Integer> descriptionDistance = Lazy.by(() -> description.get().getDistance());
@@ -584,7 +584,7 @@ public abstract class GitVersioningPluginExtension {
         placeholderMap.put("describe.tag.version.patch.plus.describe.distance", Lazy.by(() -> increase(placeholderMap.get("describe.tag.version.patch").get(), descriptionDistance.get() )));
         placeholderMap.put("describe.tag.version.patch.next.plus.describe.distance", Lazy.by(() -> increase(placeholderMap.get("describe.tag.version.patch.next").get(), descriptionDistance.get())));
 
-        placeholderMap.put("describe.tag.version.label.plus.describe.distance", Lazy.by(() -> increase(placeholderMap.get("describe.tag.version.version.label").get(), descriptionDistance.get())));
+        placeholderMap.put("describe.tag.version.label.plus.describe.distance", Lazy.by(() -> increase(placeholderMap.get("describe.tag.version.label").get(), descriptionDistance.get())));
         placeholderMap.put("describe.tag.version.label.next.plus.describe.distance", Lazy.by(() -> increase(placeholderMap.get("describe.tag.version.label.next").get(), descriptionDistance.get())));
 
         // command parameters e.g. gradle -Pfoo=123 will be available as ${property.foo}

--- a/src/test/java/me/qoomon/gradle/gitversioning/GitVersioningPluginTest.java
+++ b/src/test/java/me/qoomon/gradle/gitversioning/GitVersioningPluginTest.java
@@ -293,4 +293,60 @@ class GitVersioningPluginTest {
         // then
         assertThat(project.getVersion()).isEqualTo("679");
     }
+
+    @Test
+    void apply_TagWithSingleNonDigitPrefixGivesExpectedVersion() throws GitAPIException, IOException {
+        // given
+        Git git = Git.init().setInitialBranch(MASTER).setDirectory(projectDir.toFile()).call();
+        git.commit().setMessage("initial commit").setAllowEmpty(true).call();
+        String givenTag = "v2.0.4";
+        git.tag().setName(givenTag).call();
+
+        Project project = ProjectBuilder.builder().withProjectDir(projectDir.toFile()).build();
+
+        project.getPluginManager().apply(GitVersioningPlugin.class);
+
+        GitVersioningPluginExtension extension = (GitVersioningPluginExtension) project.getExtensions()
+                .getByName("gitVersioning");
+
+        GitVersioningPluginConfig config = new GitVersioningPluginConfig() {{
+            refs.branch(".*", patch -> {
+                patch.version = "${describe.tag.version.major}.${describe.tag.version.minor}.${describe.tag.version.patch}";
+            });
+        }};
+
+        // when
+        extension.apply(config);
+
+        // then
+        assertThat(project.getVersion()).isEqualTo("2.0.4");
+    }
+
+    @Test
+    void apply_TagWithSingleWordPrefixGivesExpectedVersion() throws GitAPIException, IOException {
+        // given
+        Git git = Git.init().setInitialBranch(MASTER).setDirectory(projectDir.toFile()).call();
+        git.commit().setMessage("initial commit").setAllowEmpty(true).call();
+        String givenTag = "alpha1.2.3";
+        git.tag().setName(givenTag).call();
+
+        Project project = ProjectBuilder.builder().withProjectDir(projectDir.toFile()).build();
+
+        project.getPluginManager().apply(GitVersioningPlugin.class);
+
+        GitVersioningPluginExtension extension = (GitVersioningPluginExtension) project.getExtensions()
+                .getByName("gitVersioning");
+
+        GitVersioningPluginConfig config = new GitVersioningPluginConfig() {{
+            refs.branch(".*", patch -> {
+                patch.version = "${describe.tag.version.major}.${describe.tag.version.minor}.${describe.tag.version.patch}";
+            });
+        }};
+
+        // when
+        extension.apply(config);
+
+        // then
+        assertThat(project.getVersion()).isEqualTo("1.2.3");
+    }
 }


### PR DESCRIPTION
- Increments minor version since the matcher could detect previously missed versions
- Fixes an issue where version.version appears to be used incorrectly in placeholders
- Fixes an issues with version matcher where versions like v1.0.0 or vxx1.0.0 would fail to match resulting in version.core being 0.0.0 instead of expected 1.0.0
- Adds a few other tests for scenarios which important to our business when using this plugin