### PR TITLE
F: Only register version for the current project

### DIFF
--- a/src/main/java/me/qoomon/gradle/gitversioning/GitVersioningPlugin.java
+++ b/src/main/java/me/qoomon/gradle/gitversioning/GitVersioningPlugin.java
@@ -14,7 +14,13 @@ public class GitVersioningPlugin implements Plugin<Project> {
 
         project.getExtensions().create("gitVersioning", GitVersioningPluginExtension.class, project);
 
-        project.getAllprojects().forEach(it -> it.getTasks().create("version", VersionTask.class));
+        // Only Register version task for current project so the plugin may be applied
+        // on
+        // sub projects. It would be nice to only define this once for all project in
+        // a multi-module project, however there are a few other considerations that
+        // need
+        // to be made and this current change will make this plugin more composable.
+        project.getTasks().register("version", VersionTask.class);
     }
 }
 


### PR DESCRIPTION
The main challenge is that currently the plugin is partially registering it self with subprojects, but not fully doing so. It should be updated to fully register and handle versioning everywhere or only do it for the project configured. This change moves it to only register for the currently configured project.

I thought of making the existing behavior conditional, however even then it didn't feel like the correct change.