### PR TITLE
update VersionTask to use Provider for project version

### DIFF
--- a/src/main/java/me/qoomon/gradle/gitversioning/VersionTask.java
+++ b/src/main/java/me/qoomon/gradle/gitversioning/VersionTask.java
@@ -4,7 +4,7 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskAction;
 
-public abstract class VersionTask extends DefaultTask {
+public class VersionTask extends DefaultTask {
     private final Provider<String> projectVersion = getProject().provider(() -> getProject().getVersion().toString());
 
     @TaskAction

--- a/src/main/java/me/qoomon/gradle/gitversioning/VersionTask.java
+++ b/src/main/java/me/qoomon/gradle/gitversioning/VersionTask.java
@@ -1,19 +1,14 @@
 package me.qoomon.gradle.gitversioning;
 
-import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.Project;
-import org.gradle.api.Task;
-import org.gradle.api.file.RegularFileProperty;
-import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.InputFile;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskAction;
 
-public class VersionTask extends DefaultTask {
-    private final Object projectVersion = getProject().getVersion();
+public abstract class VersionTask extends DefaultTask {
+    private final Provider<String> projectVersion = getProject().provider(() -> getProject().getVersion().toString());
 
     @TaskAction
     void printProjectVersion() {
-        System.out.println(projectVersion);
+        System.out.println(projectVersion.get());
     }
 }


### PR DESCRIPTION
Updates VersionTask to be compatible with the [Gradle Provider API](https://docs.gradle.org/current/userguide/lazy_configuration.html)

By setting `projectVersion` to be a final variable, this means the project version is static, and is determined in the configuration phase. This is the same phase that gradle-git-versioning-plugin also determines the version. So it's not certain whether the version will be determined *before* or *after* the VersionTask is configured. If it's *after*, then VersionTask will print 'undefined'.