### PR TITLE
fix task duplication error

### DIFF
--- a/src/main/java/me/qoomon/gradle/gitversioning/GitVersioningPlugin.java
+++ b/src/main/java/me/qoomon/gradle/gitversioning/GitVersioningPlugin.java
@@ -2,6 +2,7 @@ package me.qoomon.gradle.gitversioning;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.tasks.TaskContainer;
 
 import javax.annotation.Nonnull;
 
@@ -14,7 +15,9 @@ public class GitVersioningPlugin implements Plugin<Project> {
 
         project.getExtensions().create("gitVersioning", GitVersioningPluginExtension.class, project);
 
-        project.getTasks().register("version", VersionTask.class);
+        TaskContainer tasks = project.getTasks();
+        if(tasks.findByName("version") == null) {
+            tasks.register("version", VersionTask.class);
+        }
     }
 }
-


### PR DESCRIPTION
I have solved a problem that occurs when using dependencies declared in a buildSrc project in a multi-project configuration.

Specifically, in a multi-project configuration, the following error would occur when applying gradle-git-versioning-plugin at each level in nested projects.

```
Caused by: org.gradle.api.internal.tasks.DefaultTaskContainer$DuplicateTaskException: Cannot add task 'version' as a task with that name already exists.
	at org.gradle.api.internal.tasks.DefaultTaskContainer.failOnDuplicateTask(DefaultTaskContainer.java:257)
	at org.gradle.api.internal.tasks.DefaultTaskContainer.addTask(DefaultTaskContainer.java:250)
	at org.gradle.api.internal.tasks.DefaultTaskContainer.access$400(DefaultTaskContainer.java:76)
	at org.gradle.api.internal.tasks.DefaultTaskContainer$2.call(DefaultTaskContainer.java:298)
	at org.gradle.api.internal.tasks.DefaultTaskContainer$2.call(DefaultTaskContainer.java:292)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:204)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:199)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:66)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:59)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:157)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:59)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.call(DefaultBuildOperationRunner.java:53)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor.call(DefaultBuildOperationExecutor.java:73)
	at org.gradle.api.internal.tasks.DefaultTaskContainer.doCreate(DefaultTaskContainer.java:292)
	at org.gradle.api.internal.tasks.DefaultTaskContainer.create(DefaultTaskContainer.java:278)
	at me.qoomon.gradle.gitversioning.GitVersioningPlugin.lambda$apply$0(GitVersioningPlugin.java:17)
	at me.qoomon.gradle.gitversioning.GitVersioningPlugin.apply(GitVersioningPlugin.java:17)
	at me.qoomon.gradle.gitversioning.GitVersioningPlugin.apply(GitVersioningPlugin.java:8)
	at org.gradle.api.internal.plugins.ImperativeOnlyPluginTarget.applyImperative(ImperativeOnlyPluginTarget.java:43)
	at org.gradle.api.internal.plugins.RuleBasedPluginTarget.applyImperative(RuleBasedPluginTarget.java:51)
	at org.gradle.api.internal.plugins.DefaultPluginManager.addPlugin(DefaultPluginManager.java:187)
	at org.gradle.api.internal.plugins.DefaultPluginManager.access$100(DefaultPluginManager.java:52)
	at org.gradle.api.internal.plugins.DefaultPluginManager$AddPluginBuildOperation.run(DefaultPluginManager.java:282)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$1.execute(DefaultBuildOperationRunner.java:29)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$1.execute(DefaultBuildOperationRunner.java:26)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:66)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:59)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:157)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:59)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.run(DefaultBuildOperationRunner.java:47)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor.run(DefaultBuildOperationExecutor.java:68)
	at org.gradle.api.internal.plugins.DefaultPluginManager.lambda$doApply$0(DefaultPluginManager.java:167)
	at org.gradle.configuration.internal.DefaultUserCodeApplicationContext.apply(DefaultUserCodeApplicationContext.java:44)
	at org.gradle.api.internal.plugins.DefaultPluginManager.doApply(DefaultPluginManager.java:166)
	... 192 more
```

I have created a project configuration in my account that reproduces the situation.

https://github.com/taichi/taskdupl