### PR TITLE
feat: move extra logging to info level

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ gitVersioning.apply {
 }
 ```
 
+**Controlling Verbosity:** Use Gradle's `--info` flag to see detailed versioning configuration output.
+
 ### Configuration Options
 
 - `disable` global disable(`true`)/enable(`false`) extension, default is `false`.

--- a/src/main/java/me/qoomon/gradle/gitversioning/GitVersioningPluginExtension.java
+++ b/src/main/java/me/qoomon/gradle/gitversioning/GitVersioningPluginExtension.java
@@ -123,33 +123,34 @@ public abstract class GitVersioningPluginExtension {
             return;
         }
 
-        project.getLogger().lifecycle("matching ref: " + gitVersionDetails.getRefType().name() + " - " + gitVersionDetails.getRefName());
+
+        project.getLogger().info("matching ref: " + gitVersionDetails.getRefType().name() + " - " + gitVersionDetails.getRefName());
         final RefPatchDescription patchDescription = gitVersionDetails.getPatchDescription();
-        project.getLogger().lifecycle("  ref configuration: " + gitVersionDetails.getRefType().name() + " - pattern: " + patchDescription.pattern);
+        project.getLogger().info("  ref configuration: " + gitVersionDetails.getRefType().name() + " - pattern: " + patchDescription.pattern);
         if (patchDescription.version != null) {
-            project.getLogger().lifecycle("    version: " + patchDescription.version);
+            project.getLogger().info("    version: " + patchDescription.version);
         }
         if (!patchDescription.properties.isEmpty()) {
-            project.getLogger().lifecycle("    properties:");
-            patchDescription.properties.forEach((key, value) -> project.getLogger().lifecycle("    " + key + ": " + value));
+            project.getLogger().info("    properties:");
+            patchDescription.properties.forEach((key, value) -> project.getLogger().info("    " + key + ": " + value));
         }
         if (patchDescription.describeTagPattern != null) {
-            project.getLogger().lifecycle("    describeTagPattern: " + patchDescription.describeTagPattern);
+            project.getLogger().info("    describeTagPattern: " + patchDescription.describeTagPattern);
             gitSituation.setDescribeTagPattern(patchDescription.getDescribeTagPattern());
         }
         if (patchDescription.describeTagFirstParent != null) {
-            project.getLogger().lifecycle("    describeTagFirstParent: " + patchDescription.describeTagFirstParent);
+            project.getLogger().info("    describeTagFirstParent: " + patchDescription.describeTagFirstParent);
             gitSituation.setFirstParent(patchDescription.describeTagFirstParent);
         }
         boolean updateGradleProperties = getUpdateGradlePropertiesOption(patchDescription);
         if (updateGradleProperties) {
-            project.getLogger().lifecycle("    updateGradleProperties: true");
+            project.getLogger().info("    updateGradleProperties: true");
         }
 
         globalFormatPlaceholderMap = generateGlobalFormatPlaceholderMap(gitSituation, gitVersionDetails, project);
         Map<String, String> gitProjectProperties = generateGitProjectProperties(gitSituation, gitVersionDetails);
 
-        project.getLogger().lifecycle("");
+        project.getLogger().info("");
         project.getAllprojects().forEach(project -> {
             final String originalProjectVersion = project.getVersion().toString();
 
@@ -157,9 +158,9 @@ public abstract class GitVersioningPluginExtension {
             if (versionFormat != null) {
                 updateVersion(project, versionFormat);
                 if(project == project.getRootProject()) {
-                    project.getLogger().lifecycle("project version: " + project.getVersion());
+                    project.getLogger().info("project version: " + project.getVersion());
                 } else if (!project.getVersion().equals(project.getRootProject().getVersion())) {
-                    project.getLogger().lifecycle(project.getName()+ " > project version: " + project.getVersion());
+                    project.getLogger().info(project.getName()+ " > project version: " + project.getVersion());
                 }
             }
 


### PR DESCRIPTION
Currently the plugin prints out 5 separate log messages describing refs, configurations, versions, and describeTagFirstParent, plus a newline.

This is in addition to printing out the actual fully resolved version. The vast majority of the time this information is not valuable, but it gets printed even when running other gradle tasks (like compile!) in a project that uses this plugin.

This commit moves these messages to the info log level so they are not printed by default all the time, and instead only become visible if you add the --info (or higher) log level.

Example from my project's `compileJava` task before this change:
```
$ ./gradlew compileJava

> Configure project :
matching ref: TAG - 0.4.0-56c10c1
  ref configuration: TAG - pattern: .+
    version: ${ref}
    describeTagFirstParent: true

project version: 0.4.0-56c10c1

BUILD SUCCESSFUL in 882ms
4 actionable tasks: 4 up-to-date
```

Clearly this information is not relevant to users running the `compileJava` task.

And after this change:
```
$ ./gradlew compileJava

> Task :compileJava

BUILD SUCCESSFUL in 2s
4 actionable tasks: 1 executed, 3 up-to-date
```

And here's what it looks like when you run the `version` task:
```
$ ./gradlew :version

> Task :version
0.4.0-56c10c1

BUILD SUCCESSFUL in 522ms
1 actionable task: 1 executed
```

And
```
$ ./gradlew :version -q
0.4.0-56c10c1
```